### PR TITLE
Add api docs to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,26 +4,44 @@ name: build
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-18.04
+    env:
+      build_api_docs: "ON"
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout FLAMEGPU2/FLAMEGPU2-userguide
+      uses: actions/checkout@v2
+      with:
+        path: FLAMEGPU2-userguide
 
-    - name: Install dependencies into virtualenv
+    - name: Checkout FLAMEGPU2/FLAMEGPU2
+      if: env.build_api_docs == 'ON'
+      uses: actions/checkout@v2
+      with:
+        repository: FLAMEGPU/FLAMEGPU2
+        path: FLAMEGPU2
+
+    - name: Install doxygen
+      if: env.build_api_docs == 'ON'
+      run: sudo apt -y install doxygen
+
+    - name: Install python packages
+      working-directory: FLAMEGPU2-userguide
       run: |
         mkdir -p -m 700 .venv
         python3 -m venv .venv
         source .venv/bin/activate
         python3 -m pip install -r requirements.txt
 
-    # @todo download FLAMEGPU/FLAMEGPU to include API docs once breeze works.
     - name: Configure
+      working-directory: FLAMEGPU2-userguide
       run: |
         source .venv/bin/activate
         cmake . -B build
 
     - name: Build
+      working-directory: FLAMEGPU2-userguide/build
       run: cmake --build . --target all --verbose -j `nproc`
-      working-directory: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,38 +1,54 @@
 # Just build documentation using Doxygen - no CUDA required
-name: publish
+name: build
 
-# Only publish the contents of the master branch.
 on:
   push:
-    branches: 
-      - master
-      # - 'releases/**'
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-18.04
+    env:
+      build_api_docs: "ON"
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout FLAMEGPU2/FLAMEGPU2-userguide
+      uses: actions/checkout@v2
+      with:
+        path: FLAMEGPU2-userguide
 
-    - name: Install dependencies into virtualenv
+    - name: Checkout FLAMEGPU2/FLAMEGPU2
+      if: env.build_api_docs == 'ON'
+      uses: actions/checkout@v2
+      with:
+        repository: FLAMEGPU/FLAMEGPU2
+        path: FLAMEGPU2
+
+    - name: Install doxygen
+      if: env.build_api_docs == 'ON'
+      run: sudo apt -y install doxygen
+
+    - name: Install python packages
+      working-directory: FLAMEGPU2-userguide
       run: |
         mkdir -p -m 700 .venv
         python3 -m venv .venv
         source .venv/bin/activate
         python3 -m pip install -r requirements.txt
 
-    # @todo download FLAMEGPU/FLAMEGPU to include API docs once breeze works.
     - name: Configure
+      working-directory: FLAMEGPU2-userguide
       run: |
         source .venv/bin/activate
         cmake . -B build
 
     - name: Build
+      working-directory: FLAMEGPU2-userguide/build
       run: cmake --build . --target all --verbose -j `nproc`
-      working-directory: build
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./build/userguide/
+        publish_dir: FLAMEGPU2-userguide/build/userguide/
         # cname: flamegpu.com


### PR DESCRIPTION
CI build and publish jobs now include the API docs (via the main FLAMEGPU/FLAMEGPU2 repository)
Also adds manually invokeable CI triggers (workflow dispatch).